### PR TITLE
Addressing issue where npm isn't found on windows 

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -76,9 +76,17 @@ class NPM(Command):
     def finalize_options(self):
         pass
 
+    def get_npm_name(self):
+        npmName = 'npm';
+        if platform.system() == 'Windows':
+            npmName = 'npm.cmd';
+            
+        return npmName;
+    
     def has_npm(self):
+        npmName = self.get_npm.name();
         try:
-            check_call(['npm', '--version'])
+            check_call([npmName, '--version'])
             return True
         except:
             return False
@@ -98,7 +106,8 @@ class NPM(Command):
 
         if self.should_run_npm_install():
             log.info("Installing build dependencies with npm.  This may take a while...")
-            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
+            npmName = self.get_npm_name();
+            check_call([npmName, 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
             os.utime(self.node_modules, None)
 
         for t in self.targets:

--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -84,7 +84,7 @@ class NPM(Command):
         return npmName;
     
     def has_npm(self):
-        npmName = self.get_npm.name();
+        npmName = self.get_npm_name();
         try:
             check_call([npmName, '--version'])
             return True


### PR DESCRIPTION
This change adds 2 things

1. Method to get a name for the `npm` command based on platform (windows vs others)
1. Use the method to get the platform specific name for `npm` so that setup tools succeed

I tested on my generated widget code but I didn't see any other way to test this change.   
If there is, I'd be more than happy to run them to verify the changes.

Fixes #20 