### PR TITLE
Remove __webpack_public_path__ configuration from js/lib/index.js

### DIFF
--- a/{{cookiecutter.github_project_name}}/js/lib/index.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/index.js
@@ -1,12 +1,3 @@
-// Entry point for the notebook bundle containing custom model definitions.
-//
-// Setup notebook base URL
-//
-// Some static assets may be required by the custom widget javascript. The base
-// url for the notebook is not known at build time and is therefore computed
-// dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/{{ cookiecutter.npm_package_name }}/';
-
 // Export widget models and views, and the npm package version number.
 module.exports = require('./example.js');
 module.exports['version'] = require('../package.json').version;


### PR DESCRIPTION
As requested by @jasongrout in a discussion on gitter, this PR removes the `__webpack_public_path__` configuration and associated comments from `js/lib/index.js`.

This lines messes up the jupyterlab webpack machinery and was responsible for at least the following issues.

  - quantopian/qgrid#154
  - jupyter-widgets/ipywidgets#2053 