### PR TITLE
add watch command, normalize plugin name, fix hello world default

### DIFF
--- a/{{cookiecutter.github_project_name}}/js/lib/example.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/example.js
@@ -25,7 +25,7 @@ var HelloModel = widgets.DOMWidgetModel.extend({
         _view_module : '{{ cookiecutter.npm_package_name }}',
         _model_module_version : '{{ cookiecutter.npm_package_version }}',
         _view_module_version : '{{ cookiecutter.npm_package_version }}',
-        value : 'Hello World'
+        value : 'Hello World!'
     })
 });
 

--- a/{{cookiecutter.github_project_name}}/js/lib/labplugin.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/labplugin.js
@@ -1,4 +1,4 @@
-var {{ cookiecutter.npm_package_name }} = require('./index');
+var plugin = require('./index');
 var base = require('@jupyter-widgets/base');
 
 module.exports = {
@@ -7,8 +7,8 @@ module.exports = {
   activate: function(app, widgets) {
       widgets.registerWidget({
           name: '{{ cookiecutter.npm_package_name }}',
-          version: {{ cookiecutter.npm_package_name }}.version,
-          exports: {{ cookiecutter.npm_package_name }}
+          version: plugin.version,
+          exports: plugin
       });
   },
   autoStart: true

--- a/{{cookiecutter.github_project_name}}/js/package.json
+++ b/{{cookiecutter.github_project_name}}/js/package.json
@@ -22,6 +22,8 @@
   "scripts": {
     "clean": "rimraf dist/",
     "prepublish": "webpack",
+    "build": "webpack",
+    "watch": "webpack --watch --mode=development",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
- The default string value for Hello World is currently not the same in JS vs Python.
- Added watch command to package json
- Not use package name for import, as it can contain forbidden characters (e.g. `jupyter-plugin` wouldn't work since it contains a dash/minus.
