### PR TITLE
Fix Windows error

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -136,7 +136,7 @@ setup_args = {
             '{{ cookiecutter.python_package_name }}/static/index.js',
             '{{ cookiecutter.python_package_name }}/static/index.js.map',
         ],),
-        ('etc/jupyter/nbconfig/notebook.d/' ,['{{ cookiecutter.npm_package_name }}.json'])
+        ('etc/jupyter/nbconfig/notebook.d' ,['{{ cookiecutter.npm_package_name }}.json'])
     ],
     'install_requires': [
         'ipywidgets>=7.0.0',


### PR DESCRIPTION
Fix error on Windows: `ValueError: path 'etc/jupyter/nbconfig/notebook.d/' cannot end with '/'`