### PR TITLE
Jupyter Lab - README.md Update

### DIFF
--- a/{{cookiecutter.github_project_name}}/README.md
+++ b/{{cookiecutter.github_project_name}}/README.md
@@ -19,3 +19,14 @@ For a development installation (requires npm),
     $ pip install -e .
     $ jupyter nbextension install --py --symlink --sys-prefix {{ cookiecutter.python_package_name }}
     $ jupyter nbextension enable --py --sys-prefix {{ cookiecutter.python_package_name }}
+    $ jupyter labextension install js
+
+When actively developing your extension, build Jupyter Lab with the command:
+
+    $ jupyter lab --watch
+
+This take a minute or so to get started, but then allows you to hot-reload your javascript extension.
+To see a change, save your javascript, watch the terminal for an update.
+
+Note on first `jupyter lab --watch`, you may need to touch a file to get Jupyter Lab to open.
+


### PR DESCRIPTION
Going through this myself today I think the default Readme should summarize or duplicate the information here:

https://github.com/jupyter-widgets/ipyleaflet#installation-from-sources

Basically `jupyter lab --watch`. In my experiments, I didn't need to do a separate `npm run watch` in the `js` directory.

Perhaps saying something about: `Classic Notebook Development` and `Jupyter Lab Development` as that is a bit unclear.