### PR TITLE
Fix libraries version to work with jupyter lab 1.0.0

### DIFF
--- a/{{cookiecutter.github_project_name}}/js/package.json
+++ b/{{cookiecutter.github_project_name}}/js/package.json
@@ -31,7 +31,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0",
+    "@jupyter-widgets/base": "^2.0.0",
     "lodash": "^4.17.4"
   },
   "jupyterlab": {


### PR DESCRIPTION
Related to #29 