### PR TITLE
Add idom-jupyter as an example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ of a custom Jupyter interactive widget library.
 
 ## Who uses widget-cookiecutter
 
-Popular widget libraries such as
-[bqplot](https://github.com/bloomberg/bqplot),
-[pythreejs](https://github.com/jovyan/pythreejs) and
-[ipyleaflet](https://github.com/ellisonbg/ipyleaflet)
- can serve as advanced examples of usage of the
-Jupyter widget infrastructure.
+These widgets libraries server as advanced examples of this template's usage in the Jupyter widget ecosystem:
+
+- [bqplot](https://github.com/bloomberg/bqplot)
+- [pythreejs](https://github.com/jovyan/pythreejs)
+- [ipyleaflet](https://github.com/ellisonbg/ipyleaflet)
+- [idom-jupyter](https://github.com/idom-team/idom-jupyter)
 
 ## Usage
 


### PR DESCRIPTION
Totally understandable if you'd prefer to close this PR given that [`idom-jupyter`](https://github.com/idom-team/idom-jupyter) isn't as popular as the others listed here.

I just figured it could act as another example since it also includes an Ipython Extension and Jupyter Server Extension as well as the widget.