### PR TITLE
JupyterLab plugin ids are by convention <packagename>:<pluginname>

### DIFF
--- a/{{cookiecutter.github_project_name}}/js/lib/labplugin.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/labplugin.js
@@ -2,7 +2,7 @@ var plugin = require('./index');
 var base = require('@jupyter-widgets/base');
 
 module.exports = {
-  id: '{{ cookiecutter.npm_package_name }}',
+  id: '{{ cookiecutter.npm_package_name }}:plugin',
   requires: [base.IJupyterWidgetRegistry],
   activate: function(app, widgets) {
       widgets.registerWidget({


### PR DESCRIPTION
This makes the plugin id conform to jlab convention (important if the plugin starts using settings, etc.)