### PR TITLE
Update npm release process described in RELEASE.md

### DIFF
--- a/{{cookiecutter.github_project_name}}/RELEASE.md
+++ b/{{cookiecutter.github_project_name}}/RELEASE.md
@@ -17,6 +17,7 @@ Update `js/package.json` with new npm package version
 ```
 # clean out the `dist` and `node_modules` directories
 git clean -fdx
-npm install
-npm publish
+yarn
+yarn build:prod
+yarn publish
 ```


### PR DESCRIPTION
I noticed that npm install doesn't build all of the required files: my npm uploads don't contain the `dist/` directory, which seems to only be built when invoking `yarn build`. Since `yarn publish` also has some nice features (e.g. prompting for new version number), I thought it might be worth updating the cookiecutter.