### PR TITLE
Automatically set public path

### DIFF
--- a/{{cookiecutter.github_project_name}}/js/amd-public-path.js
+++ b/{{cookiecutter.github_project_name}}/js/amd-public-path.js
@@ -1,0 +1,8 @@
+// In an AMD module, we set the public path using the magic requirejs 'module' dependency
+// See https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#module
+// Since 'module' is a requirejs magic module, we must include 'module' in the webpack externals configuration.
+var module = require('module');
+var url = new URL(module.uri, document.location)
+// Using lastIndexOf('/')+1 gives us the empty string if there is no '/', so pathname becomes '/'
+url.pathname = url.pathname.slice(0,url.pathname.lastIndexOf('/')+1);
+__webpack_public_path__ = `${url.origin}${url.pathname}`;

--- a/{{cookiecutter.github_project_name}}/js/lib/embed.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/embed.js
@@ -1,9 +1,0 @@
-// Entry point for the unpkg bundle containing custom model definitions.
-//
-// It differs from the notebook bundle in that it does not need to define a
-// dynamic baseURL for the static assets and may load some css that would
-// already be loaded by the notebook otherwise.
-
-// Export widget models and views, and the npm package version number.
-module.exports = require('./example.js');
-module.exports['version'] = require('../package.json').version;

--- a/{{cookiecutter.github_project_name}}/js/lib/extension.js
+++ b/{{cookiecutter.github_project_name}}/js/lib/extension.js
@@ -1,12 +1,6 @@
 // This file contains the javascript that is run when the notebook is loaded.
 // It contains some requirejs configuration and the `load_ipython_extension`
 // which is required for any notebook extension.
-//
-// Some static assets may be required by the custom widget javascript. The base
-// url for the notebook is not known at build time and is therefore computed
-// dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/{{ cookiecutter.npm_package_name }}';
-
 
 // Configure requirejs
 if (window.require) {

--- a/{{cookiecutter.github_project_name}}/js/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/js/webpack.config.js
@@ -24,7 +24,6 @@ module.exports = (env, argv) => {
                 filename: 'extension.js',
                 path: path.resolve(__dirname, '..', '{{ cookiecutter.python_package_name }}', 'nbextension'),
                 libraryTarget: 'amd',
-                publicPath: '' // publicPath is set in extension.js
             },
             devtool
         },
@@ -39,7 +38,6 @@ module.exports = (env, argv) => {
                 filename: 'index.js',
                 path: path.resolve(__dirname, '..', '{{ cookiecutter.python_package_name }}', 'nbextension'),
                 libraryTarget: 'amd',
-                publicPath: '',
             },
             devtool,
             module: {
@@ -49,24 +47,19 @@ module.exports = (env, argv) => {
         },
         {// Embeddable {{ cookiecutter.npm_package_name }} bundle
         //
-        // This bundle is generally almost identical to the notebook bundle
-        // containing the custom widget views and models.
+        // This bundle is identical to the notebook bundle containing the custom
+        // widget views and models. The only difference is it is placed in the
+        // dist/ directory and shipped with the npm package for use from a CDN
+        // like jsdelivr.
         //
-        // The only difference is in the configuration of the webpack public path
-        // for the static assets.
+        // The target bundle is always `dist/index.js`, which is the path
+        // required by the custom widget embedder.
         //
-        // It will be automatically distributed by unpkg to work with the static
-        // widget embedder.
-        //
-        // The target bundle is always `dist/index.js`, which is the path required
-        // by the custom widget embedder.
-        //
-            entry: './lib/embed.js',
+            entry: './lib/index.js',
             output: {
                 filename: 'index.js',
                 path: path.resolve(__dirname, 'dist'),
                 libraryTarget: 'amd',
-                publicPath: 'https://unpkg.com/{{ cookiecutter.npm_package_name }}@' + version + '/dist/'
             },
             devtool,
             module: {

--- a/{{cookiecutter.github_project_name}}/js/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/js/webpack.config.js
@@ -33,17 +33,19 @@ module.exports = (env, argv) => {
         // custom widget.
         // It must be an amd module
         //
-            entry: './lib/index.js',
+            entry: ['./amd-public-path.js', './lib/index.js'],
             output: {
                 filename: 'index.js',
                 path: path.resolve(__dirname, '..', '{{ cookiecutter.python_package_name }}', 'nbextension'),
                 libraryTarget: 'amd',
+                publicPath: '', // Set in amd-public-path.js
             },
             devtool,
             module: {
                 rules: rules
             },
-            externals: ['@jupyter-widgets/base']
+            // 'module' is the magic requirejs dependency used to set the publicPath
+            externals: ['@jupyter-widgets/base', 'module']
         },
         {// Embeddable {{ cookiecutter.npm_package_name }} bundle
         //
@@ -55,17 +57,19 @@ module.exports = (env, argv) => {
         // The target bundle is always `dist/index.js`, which is the path
         // required by the custom widget embedder.
         //
-            entry: './lib/index.js',
+            entry: ['./amd-public-path.js', './lib/index.js'],
             output: {
                 filename: 'index.js',
                 path: path.resolve(__dirname, 'dist'),
                 libraryTarget: 'amd',
+                publicPath: '', // Set in amd-public-path.js
             },
             devtool,
             module: {
                 rules: rules
             },
-            externals: ['@jupyter-widgets/base']
+            // 'module' is the magic requirejs dependency used to set the publicPath
+            externals: ['@jupyter-widgets/base', 'module']
         }
     ];
 }

--- a/{{cookiecutter.github_project_name}}/js/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/js/webpack.config.js
@@ -18,7 +18,6 @@ module.exports = (env, argv) => {
         // some configuration for requirejs, and provides the legacy
         // "load_ipython_extension" function which is required for any notebook
         // extension.
-        //
             entry: './lib/extension.js',
             output: {
                 filename: 'extension.js',
@@ -32,7 +31,6 @@ module.exports = (env, argv) => {
         // This bundle contains the implementation for the custom widget views and
         // custom widget.
         // It must be an amd module
-        //
             entry: ['./amd-public-path.js', './lib/index.js'],
             output: {
                 filename: 'index.js',
@@ -56,7 +54,6 @@ module.exports = (env, argv) => {
         //
         // The target bundle is always `dist/index.js`, which is the path
         // required by the custom widget embedder.
-        //
             entry: ['./amd-public-path.js', './lib/index.js'],
             output: {
                 filename: 'index.js',


### PR DESCRIPTION
This is yet another attempt to automatically set the public path, this time using the requirejs magic 'module' dependency. This removes the need to hardcode public paths when compiling to AMD modules, and makes it possible to host the AMD module on any server (and does not hardcode the CDN).

This removes the difference between the classic notebook extension bundle and the CDN bundle, so we also consolidated the two webpack targets.